### PR TITLE
Issue/#5 "Feature request: guess datetime/date format in DateProcesso…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ flake8-if-statements==0.1.0
 flake8-functions==0.0.4
 flake8-annotations-coverage==0.0.4
 flake8-expression-complexity==0.0.7
+dateutils==0.6.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [flake8]
+min_python_version = 3.7
 max-complexity = 8
 max-annotations-complexity = 4
 max-line-length = 120

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -133,6 +133,12 @@ def test_multiple_processor_none_if_error():
         (['%Y-%m-%d', '%d.%m.%Y'], '20.07.2019', datetime.datetime(2019, 7, 20)),
         (['%d.%m.%Y'], None, None),
         (['%d.%m.%Y %H:%M:%S'], '20.07.2019 12:43:52', datetime.datetime(2019, 7, 20, 12, 43, 52)),
+        (None, '20.07.2019', datetime.datetime(2019, 7, 20)),
+        (None, '  20.07.2019  ', datetime.datetime(2019, 7, 20)),
+        (None, None, None),
+        (None, '20.07.2019 12:43:52', datetime.datetime(2019, 7, 20, 12, 43, 52)),
+        ([], '20.07.2019 12:43:52', datetime.datetime(2019, 7, 20, 12, 43, 52)),
+        ('', '20.07.2019 12:43:52', datetime.datetime(2019, 7, 20, 12, 43, 52)),
     ),
 )
 def test_datetime_processor(formats, value, expected_value):
@@ -148,6 +154,13 @@ def test_datetime_processor_error_value():
         assert processor('2019-01-01')
 
 
+def test_datetime_processor_error_date_value():
+    processor = DateTimeProcessor(formats=[])
+
+    with pytest.raises(ColumnError):
+        assert processor('2019_01_01')
+
+
 @pytest.mark.parametrize(
     'formats, value, expected_value',
     (
@@ -156,6 +169,11 @@ def test_datetime_processor_error_value():
         (['%Y-%m-%d', '%d.%m.%Y'], '20.07.2019', datetime.date(2019, 7, 20)),
         (['%d.%m.%Y'], None, None),
         (['%d.%m.%Y %H:%M:%S'], '20.07.2019 12:43:52', datetime.date(2019, 7, 20)),
+        (None, '20.07.2019', datetime.date(2019, 7, 20)),
+        (None, '  20.07.2019  ', datetime.date(2019, 7, 20)),
+        (None, None, None),
+        (None, '20.07.2019 12:43:52', datetime.date(2019, 7, 20)),
+        ([], '20.07.2019 12:43:52', datetime.date(2019, 7, 20)),
     ),
 )
 def test_date_processor(formats, value, expected_value):
@@ -169,6 +187,13 @@ def test_date_processor_error_value():
 
     with pytest.raises(ColumnError):
         assert processor('2019-01-01')
+
+
+def test_date_processor_error_date_value():
+    processor = DateProcessor(formats=None)
+
+    with pytest.raises(ColumnError):
+        assert processor('2019_01_01')
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
…r/DatetimeProcessor"

1. modified: import_me/processors.py Add feature to DateTimeProcessor to guess date and time whe the format = None or format = [].
2. modified:   requirements.txt Add dateutils.
3. modified:   setup.cfg Add minimal version Python 3.7
4. modified:   tests/test_processors.py Add test for new feature.

The DateTimeProcessor class has been modified. Now you can not specify the date and time format. 
If the variable is "None" or [], the opportunity will be taken to guess the format of the date and time. 
In case of failure, an error will be generated: "Unable to convert "value" to date."
Added restrictions on the version of python from 3.7 in connection with the use of "Collection" in typing.