### PR TITLE
Add optional timezone parameter to DateTimeProcessor issue/#23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ target/
 
 # pyenv
 .python-version
+/env
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.

--- a/import_me/processors.py
+++ b/import_me/processors.py
@@ -1,7 +1,9 @@
 import datetime
 import string
+import pytz.exceptions
 from decimal import Decimal, InvalidOperation
-from typing import Callable, Collection, Any, Optional, Sequence, Dict, List
+from pytz import timezone as check_timezone
+from typing import Callable, Collection, Any, Optional, Sequence, Dict, List, Union
 
 from dateutil.parser import parse
 from email_validator import validate_email, EmailNotValidError
@@ -165,10 +167,18 @@ class BooleanProcessor(BaseProcessor):
 
 
 class DateTimeProcessor(BaseProcessor):
-    def __init__(self, formats: Collection[str] = None, parser: Callable = None, **kwargs: Any) -> None:
+    def __init__(self, formats: Collection[str] = None,
+                 parser: Callable = None, timezone: Union[str, None] = None, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.formats = formats
         self.parser = parser or parse
+        self.user_timezone = None
+        if timezone:
+            try:
+                self.user_timezone = check_timezone(timezone)
+            except pytz.exceptions.UnknownTimeZoneError:
+                self.user_timezone = None
+                raise ValueError(f'Unknown time zone.')
 
     def process_value(self, value: Any) -> Any:
         if isinstance(value, str):
@@ -179,6 +189,8 @@ class DateTimeProcessor(BaseProcessor):
             value = datetime.datetime.combine(value, datetime.time.min)
         else:
             raise ColumnError(f'Unable to convert to date {value}.')
+        if self.user_timezone:
+            value = value.astimezone(self.user_timezone)
         return value
 
     def _get_datetime_from_string(self, value: str) -> datetime.datetime:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from openpyxl import Workbook
 from openpyxl.cell import Cell
 from openpyxl.worksheet.worksheet import Worksheet
+from pytz import timezone
 
 from import_me.columns import Column
 from import_me.parsers.base import BaseParser
@@ -31,6 +32,11 @@ choices_classifier_datetime_processor = [
     ['a', lambda x: datetime.date(2020, 1, 1) <= x <= datetime.date(2020, 12, 31)],
     ['b', lambda x: datetime.date(2021, 1, 1) <= x <= datetime.date(2021, 12, 31)],
 ]
+
+
+datetime_for_test = datetime.datetime(2019, 7, 20, 12, 43, 52)
+user_timezone = timezone('Europe/Moscow')
+datetime_for_test_with_user_timezone = datetime_for_test.astimezone(user_timezone)
 
 
 @pytest.fixture

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -12,7 +12,7 @@ from import_me.processors import (
 )
 from conftest import (
     raise_, choices_classifier_datetime_processor, choices_classifier_integer_processor,
-    choices_classifier_no_processor,
+    choices_classifier_no_processor, datetime_for_test_with_user_timezone,
 )
 
 
@@ -144,24 +144,32 @@ def test_multiple_processor_none_if_error():
 
 
 @pytest.mark.parametrize(
-    'formats, parser, value, expected_value',
+    'user_timezone, formats, parser, value, expected_value',
     (
-        (['%d.%m.%Y'], None, '20.07.2019', datetime.datetime(2019, 7, 20)),
-        (['%d.%m.%Y'], None, '  20.07.2019  ', datetime.datetime(2019, 7, 20)),
-        (['%Y-%m-%d', '%d.%m.%Y'], None, '20.07.2019', datetime.datetime(2019, 7, 20)),
-        (['%d.%m.%Y'], None, None, None),
-        (['%d.%m.%Y %H:%M:%S'], None, '20.07.2019 12:43:52', datetime.datetime(2019, 7, 20, 12, 43, 52)),
-        (None, None, '20.07.2019', datetime.datetime(2019, 7, 20)),
-        (None, None, '  20.07.2019  ', datetime.datetime(2019, 7, 20)),
-        (None, None, None, None),
-        (None, None, '20.07.2019 12:43:52', datetime.datetime(2019, 7, 20, 12, 43, 52)),
-        ([], None, '20.07.2019 12:43:52', datetime.datetime(2019, 7, 20, 12, 43, 52)),
-        ('', None, '20.07.2019 12:43:52', datetime.datetime(2019, 7, 20, 12, 43, 52)),
-        (None, lambda x: datetime.datetime(2020, 1, 1), '20.07.2019 12:43:52', datetime.datetime(2020, 1, 1)),
+        (None, ['%d.%m.%Y'], None, '20.07.2019', datetime.datetime(2019, 7, 20)),
+        (None, ['%d.%m.%Y'], None, '  20.07.2019  ', datetime.datetime(2019, 7, 20)),
+        (None, ['%Y-%m-%d', '%d.%m.%Y'], None, '20.07.2019', datetime.datetime(2019, 7, 20)),
+        (None, ['%d.%m.%Y'], None, None, None),
+        (None, ['%d.%m.%Y %H:%M:%S'], None, '20.07.2019 12:43:52', datetime.datetime(2019, 7, 20, 12, 43, 52)),
+        (None, None, None, '20.07.2019', datetime.datetime(2019, 7, 20)),
+        (None, None, None, '  20.07.2019  ', datetime.datetime(2019, 7, 20)),
+        (None, None, None, None, None),
+        (None, None, None, '20.07.2019 12:43:52', datetime.datetime(2019, 7, 20, 12, 43, 52)),
+        (None, [], None, '20.07.2019 12:43:52', datetime.datetime(2019, 7, 20, 12, 43, 52)),
+        (None, '', None, '20.07.2019 12:43:52', datetime.datetime(2019, 7, 20, 12, 43, 52)),
+        ('Europe/Moscow', '', None, '20.07.2019 12:43:52', datetime_for_test_with_user_timezone),
+        (
+            'Europe/Moscow',
+            ['%d.%m.%Y %H:%M:%S'],
+            None,
+            datetime_for_test_with_user_timezone,
+            datetime_for_test_with_user_timezone,
+        ),
+        (None, None, lambda x: datetime.datetime(2020, 1, 1), '20.07.2019 12:43:52', datetime.datetime(2020, 1, 1)),
     ),
 )
-def test_datetime_processor(formats, parser, value, expected_value):
-    processor = DateTimeProcessor(formats=formats, parser=parser)
+def test_datetime_processor(user_timezone, formats, parser, value, expected_value):
+    processor = DateTimeProcessor(formats=formats, parser=parser, timezone=user_timezone)
 
     assert processor(value) == expected_value
 


### PR DESCRIPTION
 I added  optional `timezone` to the `DateTimeProcessor` . Please, check it.

Changes to be committed:
	modified:   .gitignore
	modified:   import_me/processors.py
	modified:   tests/conftest.py
	modified:   tests/test_processors.py