### PR TITLE
Parser.parse(file_path) now returns ParseResult. Issue #33

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ dmypy.json
 # End of https://www.gitignore.io/api/python
 
 .idea/
+/venv/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,12 +42,12 @@ datetime_for_test_with_user_timezone = datetime_for_test.astimezone(user_timezon
 @pytest.fixture
 def base_parser():
     class Parser(BaseParser):
-        add_file_path = True
+        # add_file_path = True  # TODO: удалить, если clen_row не должен возвращать путь к файлу
         add_row_index = True
         skip_empty_rows = True
         columns = [Column('first_name', index=1)]
 
-    return Parser(file_path='test_file_path')
+    return Parser()
 
 
 @pytest.fixture
@@ -68,12 +68,12 @@ def row_factory():
 @pytest.fixture
 def xlsx_parser():
     class Parser(BaseXLSXParser):
-        add_file_path = True
+        # add_file_path = True  # TODO: удалить, если clean_row не должен возвращать путь к файлу
         add_row_index = True
         skip_empty_rows = True
         columns = [Column('first_name', index=1)]
 
-    return Parser(file_path='test_file_path')
+    return Parser()
 
 
 @pytest.fixture

--- a/tests/test_parsers/test_xlsx.py
+++ b/tests/test_parsers/test_xlsx.py
@@ -82,7 +82,7 @@ def test_base_xlsx_parser_clean_column():
         def clean_column_last_name(self, value):
             return f'Modified {value}'
 
-    parser = Parser(file_path=None)
+    parser = Parser()
 
     assert parser.clean_column(parser.columns[0], 'Test Last Name') == 'Modified Test Last Name'
     assert parser.clean_column(parser.columns[1], 'Test First Name') == 'Test First Name'
@@ -97,7 +97,7 @@ def test_base_xlsx_parser_clean_column():
     ),
 )
 def test_base_xlsx_parser_header_row_offset(header_row_index, first_data_row_index, expected_result):
-    parser = BaseXLSXParser(file_path=None)
+    parser = BaseXLSXParser()
     parser.header_row_index = header_row_index
     parser.first_data_row_index = first_data_row_index
 
@@ -164,7 +164,7 @@ def test_validate_worksheet_headers_errors(
 def test_parser_skip_empty_row(parser_skip_empty_rows, file_data, expected_data, xlsx_file_factory):
     class Parser(BaseXLSXParser):
         skip_empty_rows = parser_skip_empty_rows
-        add_file_path = False
+        # add_file_path = False  # TODO: удалить, если clean_row не должен возвращать путь к файлу
         add_row_index = False
         columns = [
             Column('column1', index=0),


### PR DESCRIPTION
Теперь функция Parser.parse() возвращает результат, а не сохраняет его в объекте Parse. Естественно, это изменение влечёт за собой несовместимость версий и переработку тестов. Если нужна совместимость (но код распухнет) - можно сделать.