### PR TITLE
Add DTO support

### DIFF
--- a/import_me/__init__.py
+++ b/import_me/__init__.py
@@ -3,4 +3,4 @@ from import_me.columns import Column
 from import_me.exceptions import StopParsing
 
 
-__version__ = '0.3.1'
+__version__ = '0.3.2'

--- a/import_me/columns.py
+++ b/import_me/columns.py
@@ -1,4 +1,5 @@
 import re
+import typing
 from typing import Callable
 
 from import_me.constants import COLUMN_NAME_PATTERN
@@ -7,8 +8,8 @@ from import_me.exceptions import ParserError
 
 class Column:
     def __init__(
-        self, name: str, index: int, processor: Callable = None,
-        header: str = None, validate_header: bool = True,
+        self, name: str, index: int, processor: typing.Optional[Callable] = None,
+        header: typing.Optional[str] = None, validate_header: bool = True,
         required: bool = False, unique: bool = False,
     ):
         self.name = name

--- a/import_me/dto.py
+++ b/import_me/dto.py
@@ -1,0 +1,261 @@
+import abc
+import dataclasses
+import datetime
+import decimal
+import pathlib
+import types
+import typing
+
+import typing_extensions
+
+import import_me
+from import_me import Column
+from import_me.parsers.base import BaseParser
+from import_me.processors import (
+    BaseProcessor,
+    IntegerProcessor,
+    StringProcessor,
+    FloatProcessor,
+    DecimalProcessor,
+    BooleanProcessor,
+    DateProcessor,
+    DateTimeProcessor,
+)
+
+META_INDEX = 'im_index'
+META_HEADER = 'im_header'
+META_VALIDATE_HEADER = 'im_validate_header'
+META_UNIQUE = 'im_unique'
+META_PROCESSOR = 'im_processor'
+
+PROCESSORS_BY_TYPE: typing.Dict[type, BaseProcessor] = {
+    int: IntegerProcessor(),
+    str: StringProcessor(),
+    float: FloatProcessor(),
+    decimal.Decimal: DecimalProcessor(),
+    bool: BooleanProcessor(),
+    datetime.date: DateProcessor(),
+    datetime.datetime: DateTimeProcessor(),
+}
+
+
+def infer_processor_by_type(field_type: typing.Any) -> typing.Optional[BaseProcessor]:
+    return PROCESSORS_BY_TYPE.get(field_type, None)
+
+
+class _NOT_SPECIFIED:
+    pass
+
+
+@dataclasses.dataclass
+class DtoField:
+    name: str
+    index: int
+    header: typing.Optional[str]
+    validate_header: bool
+    required: bool
+    unique: bool
+    processor: BaseProcessor
+    default: typing.Any = _NOT_SPECIFIED
+
+
+class DtoFieldsGetter(typing_extensions.Protocol):
+    def __call__(self, dto: typing.Any) -> typing.List[DtoField]:
+        ...
+
+
+class PydanticLikeFieldInfo(typing_extensions.Protocol):
+    extra: typing.Dict[str, typing.Any]
+
+
+class PydanticLikeField(typing_extensions.Protocol):
+    name: str
+    type_: type
+    required: bool
+    field_info: PydanticLikeFieldInfo
+    default: typing.Any
+
+
+@typing_extensions.runtime_checkable
+class PydanticLikeDto(typing_extensions.Protocol):
+    __fields__: dict[str, PydanticLikeField]
+
+
+class DataclassLikeField(typing_extensions.Protocol):
+    name: str
+    type: type  # noqa: VNE003, A003 because it is python dataclass protocol, can't be changed
+    metadata: types.MappingProxyType
+    default: typing.Any
+
+
+@typing_extensions.runtime_checkable
+class DataclassLikeDto(typing_extensions.Protocol):
+    __dataclass_fields__: dict[str, DataclassLikeField]
+
+
+def get_pydantic_fields(dto: PydanticLikeDto) -> list[DtoField]:
+    fields = []
+    index = -1
+    for field_name, pydantic_field in dto.__fields__.items():
+        if field_name == 'row_index':
+            continue
+        index = pydantic_field.field_info.extra.get(META_INDEX, index + 1)
+        fields.append(
+            DtoField(
+                name=field_name,
+                index=index,
+                header=pydantic_field.field_info.extra.get(META_HEADER),
+                validate_header=pydantic_field.field_info.extra.get(META_VALIDATE_HEADER, True),
+                unique=pydantic_field.field_info.extra.get(META_UNIQUE, False),
+                required=pydantic_field.required,
+                processor=pydantic_field.field_info.extra.get(
+                    META_PROCESSOR, infer_processor_by_type(pydantic_field.type_),
+                ),
+                default=pydantic_field.default or _NOT_SPECIFIED,
+            ),
+        )
+    return fields
+
+
+def get_dataclass_fields(dto: DataclassLikeDto) -> list[DtoField]:
+    fields = []
+    index = -1
+    for field_name, dataclass_field in dto.__dataclass_fields__.items():
+        if field_name == 'row_index':
+            continue
+        index = dataclass_field.metadata.get(META_INDEX, index + 1)
+        fields.append(
+            DtoField(
+                name=field_name,
+                index=index,
+                header=dataclass_field.metadata.get(META_HEADER, None),
+                validate_header=dataclass_field.metadata.get(META_VALIDATE_HEADER, True),
+                unique=dataclass_field.metadata.get(META_UNIQUE, False),
+                required=dataclass_field.default is dataclasses.MISSING,
+                processor=dataclass_field.metadata.get(
+                    META_PROCESSOR, infer_processor_by_type(dataclass_field.type),
+                ),
+                default=(
+                    dataclass_field.default
+                    if dataclass_field.default is not dataclasses.MISSING
+                    else _NOT_SPECIFIED
+                ),
+            ),
+        )
+    return fields
+
+
+class ImportableDtoProtocol(typing_extensions.Protocol):
+
+    def __init__(self, **kwargs: typing.Dict[str, typing.Any]) -> None:
+        ...
+
+
+T = typing.TypeVar('T', bound=typing.Union[
+    typing.Type['BaseImportableDtoMixin'], typing.Type[ImportableDtoProtocol],
+])
+
+
+@dataclasses.dataclass
+class ParsingResult(typing.Generic[T]):
+    parsed_items: list[T]
+    errors: dict[typing.Optional[int], typing.List[str]]
+
+
+class BaseImportableDtoMixin(abc.ABC):
+    """
+    Base class for DTO parser mixin.
+
+    `parser_base` is used to specify import_me parser to use.
+    Parser attributes such (e.g. `ws_index`) could be set in `ParserMeta`.
+    `fields_getter` must be a callable that gets DTO itself and returns a list of `DtoField`.
+    """
+
+    class ParserMeta:
+        pass
+
+    parser_base: typing.Type[BaseParser] = import_me.BaseXLSXParser
+    fields_getter: DtoFieldsGetter
+
+    @classmethod
+    def parse_from_file(
+        cls: typing.Type[T],
+        file_path: typing.Union[pathlib.Path, str, None] = None,
+        file_contents: typing.Optional[typing.IO] = None,
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> ParsingResult[T]:
+        fields = cls.fields_getter(cls)
+        parser = cls._construct_parser(
+            fields=fields, file_path=file_path, file_contents=file_contents, *args, **kwargs,
+        )
+        parser.parse_data(raise_errors=False)
+        parsed_items = cls._serialize_cleaned_data(parser=parser, fields=fields)
+        return ParsingResult(parsed_items, parser.errors_by_row)
+
+    @classmethod
+    def _get_columns(cls, fields: list[DtoField]) -> typing.List[Column]:
+        columns = []
+        for field in fields:
+            columns.append(
+                Column(
+                    name=field.name,
+                    index=field.index,
+                    processor=field.processor,
+                    header=field.header,
+                    validate_header=field.validate_header,
+                    required=field.required,
+                    unique=field.unique,
+                ),
+            )
+        return columns
+
+    @classmethod
+    def _construct_parser(
+        cls,
+        fields: typing.List[DtoField],
+        file_path: typing.Union[pathlib.Path, str, None] = None,
+        file_contents: typing.Optional[typing.IO] = None,
+        *args: typing.Any,
+        **kwargs: typing.Any,
+    ) -> BaseParser:
+        class DtoParser(cls.parser_base):
+            columns = cls._get_columns(fields)
+
+        for key, value in cls.ParserMeta.__dict__.items():
+            if not key.startswith('__'):
+                setattr(DtoParser, key, value)
+        return DtoParser(file_path, file_contents, *args, **kwargs)
+
+    @classmethod
+    def _serialize_cleaned_data(
+        cls: T, parser: BaseParser, fields: typing.List[DtoField],
+    ) -> typing.List[T]:
+        defaults = {field.name: field.default for field in fields}
+        parsed_items: typing.List[T] = []
+        for row in parser.cleaned_data:
+            dto_kwargs = {}
+            for key, value in row.items():
+                if value is not None:
+                    dto_kwargs[key] = value
+                else:
+                    default_value = defaults.get(key)
+                    if default_value is not _NOT_SPECIFIED:
+                        dto_kwargs[key] = default_value
+            try:
+                parsed_items.append(cls(**dto_kwargs))
+            except Exception as e:
+                parser.add_errors(
+                    str(e),
+                    row_index=row.get('row_index'),
+                    worksheet_title=row.get('worksheet'),
+                )
+        return parsed_items
+
+
+class PydanticImportableDtoMixin(BaseImportableDtoMixin):
+    fields_getter = get_pydantic_fields
+
+
+class DataclassImportableDtoMixin(BaseImportableDtoMixin):
+    fields_getter = get_dataclass_fields

--- a/import_me/exceptions.py
+++ b/import_me/exceptions.py
@@ -1,8 +1,8 @@
-from typing import List, Union
+from typing import List, Union, Optional
 
 
 class ParserError(Exception):
-    def __init__(self, messages: Union[List, str] = None) -> None:
+    def __init__(self, messages: Optional[Union[List, str]] = None) -> None:
         super().__init__(messages)
         if messages is None:
             messages = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,9 @@ xlrd==1.2.0
 email-validator==1.0.5
 pytest==5.4.1
 pytest-cov==2.8.1
-mypy==0.812
+mypy==0.991
 
+pydantic==1.9.1
 pydocstyle==5.0.2
 flake8==3.7.9
 flake8-2020==1.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ check_untyped_defs = True
 warn_unused_ignores = True
 disallow_untyped_defs = True
 allow_redefinition = True
+exclude = node_modules,env,venv,venv36
 
 [mypy-tests.*]
 ignore_errors = True

--- a/tests/test_parsers/test_dto.py
+++ b/tests/test_parsers/test_dto.py
@@ -1,0 +1,404 @@
+import dataclasses
+
+import pydantic
+
+from import_me.columns import Column
+from import_me.dto import (
+    DataclassImportableDtoMixin,
+    ParsingResult,
+    META_UNIQUE,
+    META_HEADER,
+    PydanticImportableDtoMixin,
+)
+from import_me.parsers.xlsx import BaseXLSXParser
+
+DEFAULT_WORKBOOK_DATA = {
+    'header': ['First Name', 'Last Name'],
+    'data': [['Ivan', 'Ivanov'], ['Petr', 'Petrov']],
+}
+
+DEFAULT_PARSER_COLUMNS = [
+    Column('first_name', index=0, header='First Name'),
+    Column('last_name', index=1, header='Last Name'),
+]
+
+
+def test_dataclass_dto_xlsx_parser(xlsx_file_factory):
+
+    @dataclasses.dataclass
+    class PersonDto(DataclassImportableDtoMixin):
+        parser_base = BaseXLSXParser
+        row_index: int
+        first_name: str = dataclasses.field(metadata={META_HEADER: 'First Name'})
+        last_name: str = dataclasses.field(metadata={META_HEADER: 'Last Name'})
+
+    xlsx_file = xlsx_file_factory(**DEFAULT_WORKBOOK_DATA)
+    persons = PersonDto.parse_from_file(file_path=xlsx_file.name)
+
+    assert isinstance(persons, ParsingResult)
+    assert persons.parsed_items == [
+        PersonDto(
+            first_name='Ivan',
+            last_name='Ivanov',
+            row_index=1,
+        ),
+        PersonDto(
+            first_name='Petr',
+            last_name='Petrov',
+            row_index=2,
+        ),
+    ]
+
+
+def test_dataclass_dto_xlsx_parser_accepts_file_object(xlsx_file_factory):
+    @dataclasses.dataclass
+    class PersonDto(DataclassImportableDtoMixin):
+        parser_base = BaseXLSXParser
+        row_index: int
+        first_name: str = dataclasses.field(metadata={META_HEADER: 'First Name'})
+        last_name: str = dataclasses.field(metadata={META_HEADER: 'Last Name'})
+
+    xlsx_file = xlsx_file_factory(**DEFAULT_WORKBOOK_DATA)
+    persons = PersonDto.parse_from_file(file_contents=xlsx_file)
+
+    assert isinstance(persons, ParsingResult)
+    assert persons.parsed_items == [
+        PersonDto(
+            first_name='Ivan',
+            last_name='Ivanov',
+            row_index=1,
+        ),
+        PersonDto(
+            first_name='Petr',
+            last_name='Petrov',
+            row_index=2,
+        ),
+    ]
+
+
+def test_dataclass_dto_xlsx_parser_without_header(xlsx_file_factory):
+
+    @dataclasses.dataclass
+    class PersonDto(DataclassImportableDtoMixin):
+        class ParserMeta:
+            first_data_row_index = 0
+
+        parser_base = BaseXLSXParser
+        row_index: int
+        first_name: str = dataclasses.field(metadata={META_HEADER: 'First Name'})
+        last_name: str = dataclasses.field(metadata={META_HEADER: 'Last Name'})
+
+    xlsx_file = xlsx_file_factory(
+        data=[
+            ['Ivan', 'Ivanov'],
+            ['Petr', 'Petrov'],
+        ],
+        data_row_index=0,
+    )
+    persons = PersonDto.parse_from_file(file_contents=xlsx_file)
+
+    assert isinstance(persons, ParsingResult)
+    assert persons.parsed_items == [
+        PersonDto(
+            first_name='Ivan',
+            last_name='Ivanov',
+            row_index=0,
+        ),
+        PersonDto(
+            first_name='Petr',
+            last_name='Petrov',
+            row_index=1,
+        ),
+    ]
+
+
+def test_dataclass_dto_xlsx_parser_clean_column(xlsx_file_factory):
+    @dataclasses.dataclass
+    class PersonDto(DataclassImportableDtoMixin):
+        class ParserMeta:
+            def clean_column_last_name(self, value):
+                return f'Modified {value}'
+
+        parser_base = BaseXLSXParser
+        row_index: int
+        first_name: str = dataclasses.field(metadata={META_HEADER: 'First Name'})
+        last_name: str = dataclasses.field(metadata={META_HEADER: 'Last Name'})
+
+    xlsx_file = xlsx_file_factory(**DEFAULT_WORKBOOK_DATA)
+    persons = PersonDto.parse_from_file(file_contents=xlsx_file)
+
+    assert persons.parsed_items[0].last_name == 'Modified Ivanov'
+    assert persons.parsed_items[0].first_name == 'Ivan'
+    assert persons.parsed_items[1].last_name == 'Modified Petrov'
+    assert persons.parsed_items[1].first_name == 'Petr'
+
+
+def test_parser_unique_column(xlsx_file_factory):
+    @dataclasses.dataclass
+    class IdDto(DataclassImportableDtoMixin):
+        row_index: int
+        id_: int = dataclasses.field(metadata={META_UNIQUE: True})
+
+    xlsx_file = xlsx_file_factory(
+        header=['id'],
+        data=[
+            ['1'],
+            ['2'],
+            ['1'],
+        ],
+    )
+    parsing_result = IdDto.parse_from_file(file_path=xlsx_file.file)
+
+    assert parsing_result.errors
+    assert parsing_result.errors == {3: ['row: 3, column: 0, value 1 is a duplicate of row 1']}
+    assert parsing_result.parsed_items == [
+        IdDto(**{'id_': 1, 'row_index': 1}),
+        IdDto(**{'id_': 2, 'row_index': 2}),
+    ]
+
+
+def test_dataclass_dto_xlsx_parser_default_value(xlsx_file_factory):
+    @dataclasses.dataclass
+    class PersonDto(DataclassImportableDtoMixin):
+        parser_base = BaseXLSXParser
+        row_index: int
+        first_name: str = dataclasses.field(metadata={META_HEADER: 'First Name'})
+        last_name: str = dataclasses.field(default='', metadata={META_HEADER: 'Last Name'})
+
+    xlsx_file = xlsx_file_factory(
+        data=[
+            ['First Name', 'Last Name'],
+            ['Ivan', 'Ivanov'],
+            ['Petr', None],
+        ],
+    )
+    persons = PersonDto.parse_from_file(file_contents=xlsx_file)
+
+    assert isinstance(persons, ParsingResult)
+    assert persons.parsed_items == [
+        PersonDto(
+            first_name='Ivan',
+            last_name='Ivanov',
+            row_index=1,
+        ),
+        PersonDto(
+            first_name='Petr',
+            last_name='',
+            row_index=2,
+        ),
+    ]
+    assert persons.errors == {}
+
+
+def test_dataclass_dto_xlsx_parser_no_default_value(xlsx_file_factory):
+    @dataclasses.dataclass
+    class PersonDto(DataclassImportableDtoMixin):
+        parser_base = BaseXLSXParser
+        row_index: int
+        first_name: str = dataclasses.field(metadata={META_HEADER: 'First Name'})
+        last_name: str = dataclasses.field(metadata={META_HEADER: 'Last Name'})
+
+    xlsx_file = xlsx_file_factory(
+        data=[
+            ['First Name', 'Last Name'],
+            ['Ivan', 'Ivanov'],
+            ['Petr', None],
+        ],
+    )
+    persons = PersonDto.parse_from_file(file_contents=xlsx_file)
+
+    assert isinstance(persons, ParsingResult)
+    assert persons.parsed_items == [
+        PersonDto(
+            first_name='Ivan',
+            last_name='Ivanov',
+            row_index=1,
+        ),
+    ]
+    assert persons.errors == {2: ['row: 2, column: 1, Column Last Name is required.']}
+
+
+def test_pydantic_dto_xlsx_parser(xlsx_file_factory):
+    class PersonDto(pydantic.BaseModel, PydanticImportableDtoMixin):
+        parser_base = BaseXLSXParser
+        row_index: int
+        first_name: str = pydantic.Field(**{META_HEADER: 'First Name'})
+        last_name: str = pydantic.Field(**{META_HEADER: 'Last Name'})
+
+    xlsx_file = xlsx_file_factory(**DEFAULT_WORKBOOK_DATA)
+    persons = PersonDto.parse_from_file(file_path=xlsx_file.name)
+
+    assert isinstance(persons, ParsingResult)
+    assert persons.parsed_items == [
+        PersonDto(
+            first_name='Ivan',
+            last_name='Ivanov',
+            row_index=1,
+        ),
+        PersonDto(
+            first_name='Petr',
+            last_name='Petrov',
+            row_index=2,
+        ),
+    ]
+
+
+def test_pydantic_dto_xlsx_parser_accepts_file_object(xlsx_file_factory):
+    class PersonDto(pydantic.BaseModel, PydanticImportableDtoMixin):
+        parser_base = BaseXLSXParser
+        row_index: int
+        first_name: str = pydantic.Field(**{META_HEADER: 'First Name'})
+        last_name: str = pydantic.Field(**{META_HEADER: 'Last Name'})
+
+    xlsx_file = xlsx_file_factory(**DEFAULT_WORKBOOK_DATA)
+    persons = PersonDto.parse_from_file(file_contents=xlsx_file)
+
+    assert isinstance(persons, ParsingResult)
+    assert persons.parsed_items == [
+        PersonDto(
+            first_name='Ivan',
+            last_name='Ivanov',
+            row_index=1,
+        ),
+        PersonDto(
+            first_name='Petr',
+            last_name='Petrov',
+            row_index=2,
+        ),
+    ]
+
+
+def test_pydantic_dto_xlsx_parser_without_header(xlsx_file_factory):
+    class PersonDto(pydantic.BaseModel, PydanticImportableDtoMixin):
+        class ParserMeta:
+            first_data_row_index = 0
+
+        parser_base = BaseXLSXParser
+        row_index: int
+        first_name: str = pydantic.Field(**{META_HEADER: 'First Name'})
+        last_name: str = pydantic.Field(**{META_HEADER: 'Last Name'})
+
+    xlsx_file = xlsx_file_factory(
+        data=[
+            ['Ivan', 'Ivanov'],
+            ['Petr', 'Petrov'],
+        ],
+        data_row_index=0,
+    )
+    persons = PersonDto.parse_from_file(file_contents=xlsx_file)
+
+    assert isinstance(persons, ParsingResult)
+    assert persons.parsed_items == [
+        PersonDto(
+            first_name='Ivan',
+            last_name='Ivanov',
+            row_index=0,
+        ),
+        PersonDto(
+            first_name='Petr',
+            last_name='Petrov',
+            row_index=1,
+        ),
+    ]
+
+
+def test_pydantic_dto_xlsx_parser_clean_column(xlsx_file_factory):
+    class PersonDto(pydantic.BaseModel, PydanticImportableDtoMixin):
+        class ParserMeta:
+            def clean_column_last_name(self, value):
+                return f'Modified {value}'
+
+        parser_base = BaseXLSXParser
+        row_index: int
+        first_name: str = pydantic.Field(**{META_HEADER: 'First Name'})
+        last_name: str = pydantic.Field(**{META_HEADER: 'Last Name'})
+
+    xlsx_file = xlsx_file_factory(**DEFAULT_WORKBOOK_DATA)
+    persons = PersonDto.parse_from_file(file_contents=xlsx_file)
+
+    assert persons.parsed_items[0].last_name == 'Modified Ivanov'
+    assert persons.parsed_items[0].first_name == 'Ivan'
+    assert persons.parsed_items[1].last_name == 'Modified Petrov'
+    assert persons.parsed_items[1].first_name == 'Petr'
+
+
+def test_parser_unique_column(xlsx_file_factory):
+    class IdDto(pydantic.BaseModel, PydanticImportableDtoMixin):
+        row_index: int
+        id_: int = pydantic.Field(**{META_UNIQUE: True})
+
+    xlsx_file = xlsx_file_factory(
+        header=['id'],
+        data=[
+            ['1'],
+            ['2'],
+            ['1'],
+        ],
+    )
+    parsing_result = IdDto.parse_from_file(file_path=xlsx_file.file)
+
+    assert parsing_result.errors
+    assert parsing_result.errors == {3: ['row: 3, column: 0, value 1 is a duplicate of row 1']}
+    assert parsing_result.parsed_items == [
+        IdDto(**{'id_': 1, 'row_index': 1}),
+        IdDto(**{'id_': 2, 'row_index': 2}),
+    ]
+
+
+def test_pydantic_dto_xlsx_parser_default_value(xlsx_file_factory):
+    class PersonDto(pydantic.BaseModel, PydanticImportableDtoMixin):
+        parser_base = BaseXLSXParser
+        row_index: int
+        first_name: str = pydantic.Field(**{META_HEADER: 'First Name'})
+        last_name: str = pydantic.Field(default='', **{META_HEADER: 'Last Name'})
+
+    xlsx_file = xlsx_file_factory(
+        data=[
+            ['First Name', 'Last Name'],
+            ['Ivan', 'Ivanov'],
+            ['Petr', None],
+        ],
+    )
+    persons = PersonDto.parse_from_file(file_contents=xlsx_file)
+
+    assert isinstance(persons, ParsingResult)
+    assert persons.parsed_items == [
+        PersonDto(
+            first_name='Ivan',
+            last_name='Ivanov',
+            row_index=1,
+        ),
+        PersonDto(
+            first_name='Petr',
+            last_name='',
+            row_index=2,
+        ),
+    ]
+    assert persons.errors == {}
+
+
+def test_pydantic_dto_xlsx_parser_no_default_value(xlsx_file_factory):
+    class PersonDto(pydantic.BaseModel, PydanticImportableDtoMixin):
+        parser_base = BaseXLSXParser
+        row_index: int
+        first_name: str = pydantic.Field(**{META_HEADER: 'First Name'})
+        last_name: str = pydantic.Field(**{META_HEADER: 'Last Name'})
+
+    xlsx_file = xlsx_file_factory(
+        data=[
+            ['First Name', 'Last Name'],
+            ['Ivan', 'Ivanov'],
+            ['Petr', None],
+        ],
+    )
+    persons = PersonDto.parse_from_file(file_contents=xlsx_file)
+
+    assert isinstance(persons, ParsingResult)
+    assert persons.parsed_items == [
+        PersonDto(
+            first_name='Ivan',
+            last_name='Ivanov',
+            row_index=1,
+        ),
+    ]
+    assert persons.errors == {2: ['row: 2, column: 1, Column Last Name is required.']}


### PR DESCRIPTION
This PR adds support to define parsers as Pydantic or Dataclass DTO.

It can be used like this:
```python
    class PersonDto(pydantic.BaseModel, PydanticImportableDtoMixin):
        parser_base = BaseXLSXParser
        row_index: int
        first_name: str = pydantic.Field(**{META_HEADER: 'First Name'})
        last_name: str = pydantic.Field(**{META_HEADER: 'Last Name'})

    xlsx_file = xlsx_file_factory(
        data=[
            ['First Name', 'Last Name'],
            ['Ivan', 'Ivanov'],
            ['Petr', None],
        ],
    )
    persons = PersonDto.parse_from_file(file_contents=xlsx_file)

    assert isinstance(persons, ParsingResult)
    assert persons.parsed_items == [
        PersonDto(
            first_name='Ivan',
            last_name='Ivanov',
            row_index=1,
        ),
    ]
    assert persons.errors == {2: ['row: 2, column: 1, Column Last Name is required.']}
```

Support for other DTO backends also could be easily added by the user: 
```python
def get_marshmallow_fields(dto: marshmallow.Schema) -> list[DtoField]:
    ...  # the code to extract Column attributes from DTO

class MarshmallowImportableDtoMixin(BaseImportableDtoMixin):
    fields_getter = get_marshmallow_fields
```